### PR TITLE
[fix]bugs

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,4 +4,9 @@ class Address < ApplicationRecord
   validates :post_code, presence: true, length: {maximum: 7, minimum: 7}
   validates :address, presence: true
   validates :shipname, presence: true
+
+  def address_display
+  '〒' + post_code + ' ' + address + ' ' + shipname
+  end
+
 end


### PR DESCRIPTION
次の操作をしたときのバグを修正しました。

(1)配送先として、追加の住所を登録している。
(2)通常の注文までの手続きを行う。
(3)支払方法と配送先選択の画面で、エラー

エラーの原因:
追加の配送先を選択肢として表示させる`address_display`が未定義だったため。